### PR TITLE
Add radio type for unmodified TH-D74A

### DIFF
--- a/commands/TY.md
+++ b/commands/TY.md
@@ -8,7 +8,7 @@ Returns: radio type
 
 |Model|result|detail|
 |---|---|---|
-|TH-D74A|**Need feedback**|Not modified|
+|TH-D74A|K,2|Not modified|
 |TH-D74A|K,4|Hardware extended TX modified|
 |TH-D74E|E,5|Not modified|
 |TH-D74E|E,6|Hardware extended TX modified|


### PR DESCRIPTION
I have a Kenwood TH-D74A purchased new recently, and it identifies with "K,2" in response to TY
```
ID
ID TH-D74

TY
TY K,2

FV
FV 1.06
```