### PR TITLE
fix missing parameter for MD

### DIFF
--- a/commands/MD.md
+++ b/commands/MD.md
@@ -6,7 +6,7 @@ Set mode:
 
 Get mode:
 
-	MD
+	MD p1
 
 Returns: MD p1,p2
 


### PR DESCRIPTION
from my testing with hamlib:

```
Rig command: w MD
rigctl_parse: input_line: w MD
serial_flush called
write_block called
write_block(): TX 3 bytes
0000    4d 44 0d                                            MD.             
read_string called
read_string(): RX 2 characters
0000    3f 0d                                               ?.              
Reply: ?
read_string called
read_string(): Timed out 0.250368 seconds after 0 chars

Rig command: w MD 0
rigctl_parse: input_line: w MD 0
serial_flush called
write_block called
write_block(): TX 5 bytes
0000    4d 44 20 30 0d                                      MD 0.           
read_string called
read_string(): RX 7 characters
0000    4d 44 20 30 2c 30 0d                                MD 0,0.         
Reply: MD 0,0
read_string called
read_string(): Timed out 0.250344 seconds after 0 chars

Rig command: w MD 1
rigctl_parse: input_line: w MD 1
serial_flush called
write_block called
write_block(): TX 5 bytes
0000    4d 44 20 31 0d                                      MD 1.           
read_string called
read_string(): RX 7 characters
0000    4d 44 20 31 2c 32 0d                                MD 1,2.         
Reply: MD 1,2
read_string called
read_string(): Timed out 0.250302 seconds after 0 chars

Rig command:
```

makes sense, as Band A was FM and Band B was AM