### PR TITLE
Adds info about the 'N' response from the MR command

### DIFF
--- a/commands/MR.md
+++ b/commands/MR.md
@@ -8,7 +8,7 @@ Get memory channel:
 
 	MR p1
 
-Returns: MR p2
+Returns: `MR p2` or `N` if the band is not in memory channel mode (i.e. VFO)
 
 | p1  | [Band](/tables/band.md) |
 | --- | --- |


### PR DESCRIPTION
In certain cases, the radio will return `N` as a response in the following situations when sending `MR`:

* The specified band is in VFO mode, rather than MR mode
* The radio is in single-band mode, but the opposite band is active

This might be equivalent to the 'error' beep heard when using the radio.